### PR TITLE
Improve finalize-build.bat

### DIFF
--- a/finalize-build.bat
+++ b/finalize-build.bat
@@ -1,4 +1,7 @@
 @echo off
+if exist "out/" (
+	rmdir /s /q "out" || goto :error
+)
 xcopy /s/e/y/i "images" "out/spell-builder-win32-x64/images" || goto :error
 xcopy /s/e/y/i "data" "out/spell-builder-win32-x64/data" || goto :error
 cd out || goto :error

--- a/finalize-build.bat
+++ b/finalize-build.bat
@@ -1,6 +1,11 @@
 @echo off
-xcopy /s/e/y/i %~dp0\images %~dp0\out\spell-builder-win32-x64\images
-xcopy /s/e/y/i %~dp0\data %~dp0\out\spell-builder-win32-x64\data
-cd out
-set /p "version=Enter current version: "
-tar.exe -a -c -f spell-builder-%version%.zip spell-builder-win32-x64
+xcopy /s/e/y/i "images" "out/spell-builder-win32-x64/images" || goto :error
+xcopy /s/e/y/i "data" "out/spell-builder-win32-x64/data" || goto :error
+cd out || goto :error
+set /p "version=Enter current version: " || goto :error
+tar -a -c -f "spell-builder-%version%.zip" "spell-builder-win32-x64" || goto :error
+goto :EOF
+
+:error
+echo "Failed with error #%errorlevel%."
+exit /b %errorlevel%


### PR DESCRIPTION
- Quotes paths and strings to prevent accidental breakage
  *(could break before by for example entering a version containing a space)*
- Uses forward slashes for paths
  *(slightly more portable across tools)*
- Replaces current path macro with relative paths
  *(much more commonly understood)*
- Adds error checking

Has been tested to work.