### PR TITLE
Trim Package Manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "spell-builder",
-  "version": "1.0.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spell-builder",
-      "version": "1.0.2",
-      "license": "UNLICENSED",
+      "version": "1.3.3",
       "dependencies": {
         "electron-log": "^5.1.1",
         "electron-squirrel-startup": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "run.js",
   "scripts": {
     "start": "electron-forge start",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "",
     "package": "electron-forge package",
     "make": "electron-forge make"
   },
@@ -13,12 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/MegaGlub/spell-builder.git"
   },
-  "keywords": [
-    "not",
-    "applicable"
-  ],
   "author": "MegaGlub",
-  "license": "UNLICENSED",
   "bugs": {
     "url": "https://github.com/MegaGlub/spell-builder/issues"
   },


### PR DESCRIPTION
- Removes unnecessary keywords field
  *(if published as is, this would apply nonsensical keywords)*
- Removes unnecessary license field
  This is assuming the previous intent was to specify no license whatsoever. This is the default as per copyright if nothing is specified, and this field is optional. In fact if anything, explicitly specifying `UNLICENSED` only makes it possible to confuse it with a declaration that this project is licensed under [The Unlicense](https://choosealicense.com/licenses/unlicense/), a public dedication license.
- Replaces erroring test stub with an empty command
  A project with no tests should implicitly succeed its tests; this allows forwards compatible CI checks.
- Updates package-lock for spell-builder